### PR TITLE
Add WAL-based persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Your vectors are saved in `my_vectors.db`.
 - **Filters** results by metadata
 - **Works offline** - no internet required
 
+## Persistence Model
+
+VectorLiteDB keeps the main database in `my_vectors.db` and uses a sidecar write-ahead
+log at `my_vectors.db.wal` while writes are in flight.
+
+- `insert()` and `delete()` append a durable WAL record immediately
+- opening a database replays any WAL records on top of the last snapshot
+- `close()` checkpoints the in-memory state back into the main DB file and clears the WAL
+- long-running write sessions checkpoint periodically to keep the WAL from growing forever
+
+This keeps normal writes cheap while preserving crash recovery and single-file snapshot
+compatibility for the main database format.
+
 ## What This Doesn't Do (Yet)
 
 - ❌ Generate embeddings (use OpenAI, etc.)

--- a/src/vectorlitedb/db.py
+++ b/src/vectorlitedb/db.py
@@ -2,11 +2,13 @@
 VectorLiteDB - A simple embedded vector database
 """
 
-import os
 import json
+import os
 import struct
+from json import JSONDecodeError
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
 import numpy as np
-from typing import List, Dict, Any, Tuple, Optional, Callable
 
 # ============== Core Database Class ==============
 
@@ -17,6 +19,9 @@ class VectorLiteDB:
 
     Like SQLite, but for vectors. Stores everything in a single file.
     """
+
+    # Keep the WAL bounded without adding a public tuning surface yet.
+    _CHECKPOINT_INTERVAL = 100
 
     def __init__(
         self,
@@ -33,13 +38,16 @@ class VectorLiteDB:
             distance_metric: One of "cosine", "l2", or "dot"
         """
         self.db_path = db_path
-        self._read_only = False  # Track if database is read-only
+        self._wal_path = self._get_wal_path()
+        self._read_only = False
+        self._dirty_ops = 0
 
         # Validate distance metric
         valid_metrics = {"cosine", "l2", "dot"}
         if distance_metric not in valid_metrics:
             raise ValueError(
-                f"Invalid distance_metric: {distance_metric}. Must be one of {valid_metrics}"
+                "Invalid distance_metric: "
+                f"{distance_metric}. Must be one of {valid_metrics}"
             )
         self.distance_metric = distance_metric
 
@@ -49,10 +57,10 @@ class VectorLiteDB:
 
         # Load existing or create new
         if os.path.exists(db_path) and os.path.getsize(db_path) > 0:
-            self._load()
-            # Check if file is writable
+            self._load_snapshot()
             if not os.access(db_path, os.W_OK):
                 self._read_only = True
+            self._replay_wal()
         else:
             if dimension is None:
                 raise ValueError("Dimension required for new database")
@@ -66,7 +74,7 @@ class VectorLiteDB:
                 raise ValueError(f"Dimension must be non-negative, got {dimension}")
 
             self.dimension = dimension
-            self._save()
+            self._write_snapshot()
 
     def insert(
         self, id: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None
@@ -82,21 +90,34 @@ class VectorLiteDB:
         if self._read_only:
             raise PermissionError("Cannot insert into read-only database")
 
-        # Validate
         if id in self.vectors:
             raise ValueError(f"ID already exists: {id}")
 
         if len(vector) != self.dimension:
             raise ValueError(
-                f"Vector dimension mismatch: expected {self.dimension}, got {len(vector)}"
+                "Vector dimension mismatch: "
+                f"expected {self.dimension}, got {len(vector)}"
             )
 
-        # Store
         self.vectors[id] = vector
         self.metadata[id] = metadata
 
-        # Persist
-        self._save()
+        try:
+            self._append_wal_record(
+                {
+                    "op": "insert",
+                    "id": id,
+                    "vector": vector,
+                    "metadata": metadata,
+                }
+            )
+        except BaseException:
+            del self.vectors[id]
+            del self.metadata[id]
+            raise
+
+        self._dirty_ops += 1
+        self._maybe_checkpoint()
 
     def search(
         self,
@@ -118,28 +139,23 @@ class VectorLiteDB:
         if not self.vectors:
             return []
 
-        # Calculate distances to all vectors
         distances = []
         for vec_id, vector in self.vectors.items():
-            # Apply filter if provided
             if filter and vec_id in self.metadata:
                 meta = self.metadata[vec_id]
                 if meta is None or not filter(meta):
                     continue
 
-            # Calculate distance
             distance = self._calculate_distance(query, vector)
             distances.append((vec_id, distance))
 
-        # Sort and get top k
         distances.sort(key=lambda x: x[1])
         results = []
 
         for vec_id, distance in distances[:top_k]:
-            # Convert distance to similarity score
             if self.distance_metric in ["l2", "cosine"]:
                 similarity = 1.0 / (1.0 + distance)
-            else:  # dot product
+            else:
                 similarity = -distance
 
             results.append(
@@ -165,10 +181,21 @@ class VectorLiteDB:
         if id not in self.vectors:
             raise KeyError(f"ID not found: {id}")
 
+        vector = self.vectors[id]
+        metadata = self.metadata[id]
+
         del self.vectors[id]
         del self.metadata[id]
 
-        self._save()
+        try:
+            self._append_wal_record({"op": "delete", "id": id})
+        except BaseException:
+            self.vectors[id] = vector
+            self.metadata[id] = metadata
+            raise
+
+        self._dirty_ops += 1
+        self._maybe_checkpoint()
 
     def get(self, id: str) -> Tuple[List[float], Optional[Dict[str, Any]]]:
         """
@@ -186,61 +213,135 @@ class VectorLiteDB:
         return self.vectors[id], self.metadata[id]
 
     def close(self) -> None:
-        """Save and close the database."""
-        if not self._read_only:
-            self._save()
+        """Checkpoint pending WAL changes and close the database."""
+        if self._read_only:
+            return
+
+        if self._has_pending_wal():
+            self._checkpoint()
 
     # ============== Internal Methods ==============
 
     def _calculate_distance(self, v1: List[float], v2: List[float]) -> float:
         """Calculate distance between two vectors."""
-        v1_array = np.array(v1, dtype=np.float64)  # Use float64 for better precision
+        v1_array = np.array(v1, dtype=np.float64)
         v2_array = np.array(v2, dtype=np.float64)
 
-        # Check for NaN or Inf values
         if np.any(np.isnan(v1_array)) or np.any(np.isnan(v2_array)):
-            return float("inf")  # Return infinite distance for NaN vectors
+            return float("inf")
 
         if self.distance_metric == "l2":
             distance = float(np.linalg.norm(v1_array - v2_array))
             return distance if np.isfinite(distance) else float("inf")
 
-        elif self.distance_metric == "cosine":
-            # Cosine distance = 1 - cosine similarity
+        if self.distance_metric == "cosine":
             norm1 = np.linalg.norm(v1_array)
             norm2 = np.linalg.norm(v2_array)
             if norm1 == 0 or norm2 == 0:
                 return 1.0
 
-            # Handle overflow/underflow
             if np.isinf(norm1) or np.isinf(norm2):
                 return float("inf")
 
             similarity = np.dot(v1_array, v2_array) / (norm1 * norm2)
-
-            # Clamp similarity to [-1, 1] to handle numerical errors
             similarity = np.clip(similarity, -1.0, 1.0)
             distance = float(1 - similarity)
             return distance if np.isfinite(distance) else float("inf")
 
-        elif self.distance_metric == "dot":
-            # Negative dot product (higher dot = more similar = lower distance)
+        if self.distance_metric == "dot":
             dot_product = np.dot(v1_array, v2_array)
             return float(-dot_product) if np.isfinite(dot_product) else float("inf")
 
-        else:
-            raise ValueError(f"Unknown distance metric: {self.distance_metric}")
+        raise ValueError(f"Unknown distance metric: {self.distance_metric}")
 
-    def _save(self) -> None:
-        """Save database to file atomically to prevent corruption."""
+    def _get_wal_path(self) -> str:
+        """Return the sidecar WAL path for this database."""
+        return self.db_path + ".wal"
+
+    def _ensure_db_directory(self) -> None:
+        """Create the parent directory for the database files if needed."""
         os.makedirs(os.path.dirname(os.path.abspath(self.db_path)), exist_ok=True)
 
-        # Write to a temporary file first, then atomically replace.
-        # This prevents data loss if the process crashes mid-write.
+    def _append_wal_record(self, record: Dict[str, Any]) -> None:
+        """Append a single durable WAL record as JSON Lines."""
+        self._ensure_db_directory()
+
+        with open(self._wal_path, "a", encoding="utf-8") as wal_file:
+            wal_file.write(json.dumps(record))
+            wal_file.write("\n")
+            wal_file.flush()
+            os.fsync(wal_file.fileno())
+
+    def _apply_wal_record(self, record: Dict[str, Any]) -> None:
+        """Apply a single WAL record to the in-memory state."""
+        op = record.get("op")
+        if op == "insert":
+            self.vectors[record["id"]] = record["vector"]
+            self.metadata[record["id"]] = record.get("metadata")
+            return
+
+        if op == "delete":
+            self.vectors.pop(record["id"], None)
+            self.metadata.pop(record["id"], None)
+            return
+
+        raise ValueError(f"Unknown WAL operation: {op}")
+
+    def _replay_wal(self) -> None:
+        """Replay the WAL into memory, ignoring only a truncated final record."""
+        if not self._has_pending_wal():
+            return
+
+        with open(self._wal_path, "r", encoding="utf-8") as wal_file:
+            lines = wal_file.readlines()
+
+        for index, line in enumerate(lines):
+            raw_line = line.strip()
+            if not raw_line:
+                continue
+
+            try:
+                record = json.loads(raw_line)
+            except JSONDecodeError as exc:
+                is_last_line = index == len(lines) - 1
+                # A missing trailing newline likely means the process crashed mid-write.
+                # Ignore only that incomplete tail so earlier committed records survive.
+                if is_last_line and not line.endswith("\n"):
+                    break
+                raise ValueError("Invalid WAL format") from exc
+
+            self._apply_wal_record(record)
+
+    def _maybe_checkpoint(self) -> None:
+        """Checkpoint after enough pending WAL operations have accumulated."""
+        if self._dirty_ops >= self._CHECKPOINT_INTERVAL:
+            self._checkpoint()
+
+    def _has_pending_wal(self) -> bool:
+        """Return True when a non-empty WAL file exists."""
+        return os.path.exists(self._wal_path) and os.path.getsize(self._wal_path) > 0
+
+    def _checkpoint(self) -> None:
+        """Merge the in-memory state back into the main snapshot and clear the WAL."""
+        if self._read_only:
+            raise PermissionError("Cannot checkpoint read-only database")
+
+        if not self._has_pending_wal():
+            self._dirty_ops = 0
+            return
+
+        self._write_snapshot()
+        # Clear the WAL only after the snapshot replace succeeds.
+        os.remove(self._wal_path)
+        self._dirty_ops = 0
+
+    def _write_snapshot(self) -> None:
+        """Save database to the main file atomically to prevent corruption."""
+        self._ensure_db_directory()
+
         temp_path = self.db_path + ".tmp"
         try:
-            with open(temp_path, "wb") as f:
-                # Write header
+            with open(temp_path, "wb") as snapshot_file:
                 header = {
                     "magic": "VLDB",
                     "version": 1,
@@ -249,32 +350,27 @@ class VectorLiteDB:
                     "count": len(self.vectors),
                 }
                 header_json = json.dumps(header).encode("utf-8")
-                f.write(struct.pack("I", len(header_json)))
-                f.write(header_json)
+                snapshot_file.write(struct.pack("I", len(header_json)))
+                snapshot_file.write(header_json)
 
-                # Write vectors and metadata
                 data = {"vectors": self.vectors, "metadata": self.metadata}
                 data_json = json.dumps(data).encode("utf-8")
-                f.write(data_json)
+                snapshot_file.write(data_json)
 
-                # Flush to OS and sync to disk
-                f.flush()
-                os.fsync(f.fileno())
+                snapshot_file.flush()
+                os.fsync(snapshot_file.fileno())
 
-            # Atomically replace the old file with the new one
             os.replace(temp_path, self.db_path)
         except BaseException:
-            # Clean up temp file on any failure
             if os.path.exists(temp_path):
                 os.remove(temp_path)
             raise
 
-    def _load(self) -> None:
-        """Load database from file."""
-        with open(self.db_path, "rb") as f:
-            # Read header
-            header_size = struct.unpack("I", f.read(4))[0]
-            header_json = f.read(header_size)
+    def _load_snapshot(self) -> None:
+        """Load database from the main snapshot file."""
+        with open(self.db_path, "rb") as snapshot_file:
+            header_size = struct.unpack("I", snapshot_file.read(4))[0]
+            header_json = snapshot_file.read(header_size)
             header = json.loads(header_json.decode("utf-8"))
 
             if header["magic"] != "VLDB":
@@ -283,8 +379,7 @@ class VectorLiteDB:
             self.dimension = header["dimension"]
             self.distance_metric = header["distance_metric"]
 
-            # Read data
-            data_json = f.read()
+            data_json = snapshot_file.read()
             data = json.loads(data_json.decode("utf-8"))
 
             self.vectors = data["vectors"]
@@ -302,4 +397,7 @@ class VectorLiteDB:
         return len(self.vectors)
 
     def __repr__(self):
-        return f"VectorLiteDB(path='{self.db_path}', vectors={len(self.vectors)}, dim={self.dimension})"
+        return (
+            f"VectorLiteDB(path='{self.db_path}', vectors={len(self.vectors)}, "
+            f"dim={self.dimension})"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@ Shared pytest fixtures for VectorLiteDB tests
 
 import os
 import tempfile
-import pytest
+
 import numpy as np
+import pytest
+
 from vectorlitedb import VectorLiteDB
 
 
@@ -20,8 +22,9 @@ def temp_db_path():
     yield db_path
     
     # Cleanup
-    if os.path.exists(db_path):
-        os.remove(db_path)
+    for path in [db_path, db_path + ".wal", db_path + ".tmp"]:
+        if os.path.exists(path):
+            os.remove(path)
 
 
 @pytest.fixture

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3,360 +3,454 @@ Test data persistence and file operations
 """
 
 import os
-import tempfile
+
+import numpy as np
 import pytest
+
 from vectorlitedb import VectorLiteDB
 
 
+def get_wal_path(db_path):
+    """Return the expected WAL path for a database file."""
+    return db_path + ".wal"
+
+
 class TestBasicPersistence:
-    
     def test_data_persists_after_close(self, temp_db_path, sample_vectors):
-        """Test that data persists after closing and reopening database"""
-        # Create and populate database
+        """Test that data persists after closing and reopening database."""
         db1 = VectorLiteDB(temp_db_path, dimension=3, distance_metric="l2")
-        
+
         for vec_id, vector in sample_vectors.items():
             metadata = {"id": vec_id, "persisted": True}
             db1.insert(vec_id, vector, metadata)
-        
+
         initial_count = len(db1)
         db1.close()
-        
-        # Reopen database
+
         db2 = VectorLiteDB(temp_db_path)
-        
-        # Verify all data persisted
+
         assert len(db2) == initial_count
         assert db2.dimension == 3
         assert db2.distance_metric == "l2"
-        
+
         for vec_id, expected_vector in sample_vectors.items():
             vector, metadata = db2.get(vec_id)
             assert vector == expected_vector
             assert metadata["id"] == vec_id
             assert metadata["persisted"] is True
-        
+
         db2.close()
-    
+
     def test_search_works_after_reopen(self, temp_db_path, sample_vectors):
-        """Test that search functionality works after reopening database"""
-        # Create and populate
+        """Test that search functionality works after reopening database."""
         db1 = VectorLiteDB(temp_db_path, dimension=3)
         for vec_id, vector in sample_vectors.items():
             db1.insert(vec_id, vector)
         db1.close()
-        
-        # Reopen and search
+
         db2 = VectorLiteDB(temp_db_path)
         results = db2.search([1.0, 0.0, 0.0], top_k=3)
-        
+
         assert len(results) > 0
-        assert results[0]["id"] == "vec1"  # Should find exact match
+        assert results[0]["id"] == "vec1"
         assert results[0]["similarity"] > 0.99
-        
+
         db2.close()
-    
+
     def test_multiple_close_calls(self, temp_db_path, sample_vectors):
-        """Test that multiple close() calls don't cause issues"""
+        """Test that multiple close() calls don't cause issues."""
         db = VectorLiteDB(temp_db_path, dimension=3)
         db.insert("test", sample_vectors["vec1"])
-        
-        # Multiple closes should be safe
+
         db.close()
         db.close()
         db.close()
-        
-        # Verify data still accessible after reopen
+
+        assert not os.path.exists(get_wal_path(temp_db_path))
+
         db2 = VectorLiteDB(temp_db_path)
         vector, _ = db2.get("test")
         assert vector == sample_vectors["vec1"]
         db2.close()
-    
-    def test_automatic_save_on_operations(self, temp_db_path, sample_vectors):
-        """Test that operations automatically save to disk"""
+
+    def test_insert_persists_across_reopen_without_close(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test that inserts are visible through WAL replay before close."""
         db = VectorLiteDB(temp_db_path, dimension=3)
-        
-        # Insert without explicit close
         db.insert("auto_save", sample_vectors["vec1"])
-        
-        # Open new instance - data should be there
+
+        assert os.path.exists(get_wal_path(temp_db_path))
+
         db2 = VectorLiteDB(temp_db_path)
         vector, _ = db2.get("auto_save")
         assert vector == sample_vectors["vec1"]
-        
+
+        db.close()
+        db2.close()
+
+    def test_delete_persists_across_reopen_without_close(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test that deletes are visible through WAL replay before close."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        db.insert("delete_me", sample_vectors["vec1"])
+        db.close()
+
+        db = VectorLiteDB(temp_db_path)
+        db.delete("delete_me")
+
+        db2 = VectorLiteDB(temp_db_path)
+        with pytest.raises(KeyError):
+            db2.get("delete_me")
+
         db.close()
         db2.close()
 
 
+class TestWALPersistence:
+    def test_existing_snapshot_without_wal_opens_unchanged(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test that a plain snapshot file still opens without WAL involvement."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        db.insert("snap", sample_vectors["vec1"], {"source": "snapshot"})
+        db.close()
+
+        wal_path = get_wal_path(temp_db_path)
+        assert not os.path.exists(wal_path)
+
+        reopened = VectorLiteDB(temp_db_path)
+        vector, metadata = reopened.get("snap")
+        assert vector == sample_vectors["vec1"]
+        assert metadata == {"source": "snapshot"}
+        reopened.close()
+
+    def test_wal_grows_with_data_before_checkpoint(self, temp_db_path):
+        """Test that writes accumulate in WAL until a checkpoint happens."""
+        db = VectorLiteDB(temp_db_path, dimension=100)
+        wal_path = get_wal_path(temp_db_path)
+        initial_db_size = os.path.getsize(temp_db_path)
+
+        for i in range(50):
+            vector = [float(i)] * 100
+            metadata = {"index": i, "data": "x" * 100}
+            db.insert(f"vec_{i}", vector, metadata)
+
+        assert os.path.exists(wal_path)
+        assert os.path.getsize(wal_path) > 1000
+        assert os.path.getsize(temp_db_path) == initial_db_size
+
+        db.close()
+
+        assert not os.path.exists(wal_path)
+        assert os.path.getsize(temp_db_path) > initial_db_size
+
+    def test_checkpoint_on_close_compacts_state_and_clears_wal(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test that close checkpoints the latest state into the main snapshot."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        wal_path = get_wal_path(temp_db_path)
+        for vec_id, vector in sample_vectors.items():
+            db.insert(vec_id, vector, {"data": "x" * 1000})
+
+        snapshot_size_before_close = os.path.getsize(temp_db_path)
+        wal_size_before_close = os.path.getsize(wal_path)
+        assert wal_size_before_close > 0
+
+        for vec_id in list(sample_vectors.keys())[:-1]:
+            db.delete(vec_id)
+
+        assert os.path.getsize(wal_path) > wal_size_before_close
+
+        db.close()
+
+        assert not os.path.exists(wal_path)
+        assert os.path.getsize(temp_db_path) > snapshot_size_before_close
+
+        reopened = VectorLiteDB(temp_db_path)
+        assert len(reopened) == 1
+        vector, metadata = reopened.get("vec5")
+        assert vector == sample_vectors["vec5"]
+        assert metadata["data"] == "x" * 1000
+        reopened.close()
+
+    def test_threshold_checkpoint_clears_wal_during_long_running_session(
+        self, temp_db_path, sample_vectors, monkeypatch
+    ):
+        """Test that the op threshold triggers a checkpoint before close."""
+        monkeypatch.setattr(VectorLiteDB, "_CHECKPOINT_INTERVAL", 2)
+
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        wal_path = get_wal_path(temp_db_path)
+
+        db.insert("vec1", sample_vectors["vec1"])
+        assert os.path.exists(wal_path)
+
+        db.insert("vec2", sample_vectors["vec2"])
+        assert not os.path.exists(wal_path)
+
+        reopened = VectorLiteDB(temp_db_path)
+        assert len(reopened) == 2
+        reopened.close()
+        db.close()
+
+    def test_duplicate_insert_and_missing_delete_do_not_append_invalid_wal_entries(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test that failing writes leave the WAL unchanged."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        wal_path = get_wal_path(temp_db_path)
+
+        with pytest.raises(KeyError, match="ID not found: missing"):
+            db.delete("missing")
+        assert not os.path.exists(wal_path)
+
+        db.insert("vec1", sample_vectors["vec1"])
+        wal_size = os.path.getsize(wal_path)
+
+        with pytest.raises(ValueError, match="ID already exists: vec1"):
+            db.insert("vec1", sample_vectors["vec2"])
+        assert os.path.getsize(wal_path) == wal_size
+
+        with pytest.raises(KeyError, match="ID not found: missing"):
+            db.delete("missing")
+        assert os.path.getsize(wal_path) == wal_size
+
+        db.close()
+
+    def test_startup_recovery_replays_latest_wal_state(
+        self, temp_db_path, sample_vectors
+    ):
+        """Test crash-style recovery by reopening without checkpointing first."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        db.insert("vec1", sample_vectors["vec1"])
+        db.insert("vec2", sample_vectors["vec2"])
+        db.delete("vec1")
+
+        recovered = VectorLiteDB(temp_db_path)
+        with pytest.raises(KeyError):
+            recovered.get("vec1")
+
+        vector, _ = recovered.get("vec2")
+        assert vector == sample_vectors["vec2"]
+
+        recovered.close()
+        db.close()
+
+    def test_truncated_final_wal_record_is_ignored(self, temp_db_path, sample_vectors):
+        """Test that a partial final WAL line does not corrupt valid prior records."""
+        db = VectorLiteDB(temp_db_path, dimension=3)
+        db.insert("vec1", sample_vectors["vec1"])
+        wal_path = get_wal_path(temp_db_path)
+
+        with open(wal_path, "a", encoding="utf-8") as wal_file:
+            wal_file.write('{"op":"insert","id":"broken"')
+
+        recovered = VectorLiteDB(temp_db_path)
+        vector, _ = recovered.get("vec1")
+        assert vector == sample_vectors["vec1"]
+
+        with pytest.raises(KeyError):
+            recovered.get("broken")
+
+        recovered.close()
+        db.close()
+
+
 class TestFileFormat:
-    
     def test_file_created_on_init(self, temp_db_path):
-        """Test that database file is created on initialization"""
+        """Test that database file is created on initialization."""
         assert not os.path.exists(temp_db_path)
-        
+
         db = VectorLiteDB(temp_db_path, dimension=5)
-        
-        # File should exist after creation
+
         assert os.path.exists(temp_db_path)
         assert os.path.isfile(temp_db_path)
         assert os.path.getsize(temp_db_path) > 0
-        
-        db.close()
-    
-    def test_file_grows_with_data(self, temp_db_path):
-        """Test that file size grows as data is added"""
-        db = VectorLiteDB(temp_db_path, dimension=100)
-        
-        initial_size = os.path.getsize(temp_db_path)
-        
-        # Add many vectors
-        for i in range(50):
-            vector = [float(i)] * 100
-            metadata = {"index": i, "data": "x" * 100}  # Some bulk
-            db.insert(f"vec_{i}", vector, metadata)
-        
-        final_size = os.path.getsize(temp_db_path)
-        
-        # File should have grown significantly
-        assert final_size > initial_size + 1000  # At least 1KB growth
-        
-        db.close()
-    
-    def test_file_shrinks_on_delete(self, temp_db_path, sample_vectors):
-        """Test file behavior when deleting data"""
-        db = VectorLiteDB(temp_db_path, dimension=3)
-        
-        # Add data
-        for vec_id, vector in sample_vectors.items():
-            large_metadata = {"data": "x" * 1000}  # 1KB per vector
-            db.insert(vec_id, vector, large_metadata)
-        
-        size_after_insert = os.path.getsize(temp_db_path)
-        
-        # Delete most data
-        for vec_id in list(sample_vectors.keys())[:-1]:
-            db.delete(vec_id)
-        
-        size_after_delete = os.path.getsize(temp_db_path)
-        
-        # Note: Current implementation rewrites entire file, so size should decrease
-        assert size_after_delete < size_after_insert
-        
+        assert not os.path.exists(get_wal_path(temp_db_path))
+
         db.close()
 
 
 class TestFileSystemEdgeCases:
-    
     def test_readonly_file_fails_gracefully(self, temp_db_path, sample_vectors):
-        """Test behavior when file becomes read-only"""
-        # Create database
+        """Test behavior when file becomes read-only."""
         db = VectorLiteDB(temp_db_path, dimension=3)
         db.insert("test", sample_vectors["vec1"])
         db.close()
-        
-        # Make file read-only
-        os.chmod(temp_db_path, 0o444)  # Read-only
-        
+
+        os.chmod(temp_db_path, 0o444)
+
         try:
-            # Should still be able to read
             db2 = VectorLiteDB(temp_db_path)
             vector, _ = db2.get("test")
             assert vector == sample_vectors["vec1"]
-            
-            # But writes should fail
+
             with pytest.raises(PermissionError):
                 db2.insert("new", sample_vectors["vec2"])
-            
+
             db2.close()
-            
         finally:
-            # Restore permissions for cleanup
             os.chmod(temp_db_path, 0o644)
-    
+
     def test_disk_full_simulation(self, temp_db_path):
-        """Test behavior when disk is full (simulated)"""
-        # This is hard to test reliably, but we can test with a very large vector
-        db = VectorLiteDB(temp_db_path, dimension=1000000)  # Very large
-        
-        # This might fail due to memory/disk constraints
-        # The test verifies the error is handled gracefully
+        """Test behavior when disk is full (simulated)."""
+        db = VectorLiteDB(temp_db_path, dimension=1000000)
+
         try:
             huge_vector = [1.0] * 1000000
             db.insert("huge", huge_vector)
         except (MemoryError, OSError):
-            # These are acceptable failures for huge data
             pass
-        
+
         db.close()
-    
+
     def test_concurrent_file_access(self, temp_db_path, sample_vectors):
-        """Test that concurrent access is handled appropriately"""
-        # Create first database instance
+        """Test that concurrent access is handled appropriately."""
         db1 = VectorLiteDB(temp_db_path, dimension=3)
         db1.insert("from_db1", sample_vectors["vec1"])
-        
-        # Try to open second instance on same file
-        # Current implementation doesn't support concurrent writes
-        # This test documents the current behavior
+
         db2 = VectorLiteDB(temp_db_path)
-        
-        # Reading from both should work
+
         vector1, _ = db1.get("from_db1")
         vector2, _ = db2.get("from_db1")
         assert vector1 == vector2
-        
-        # Writing from both is undefined behavior in current version
-        # This test just ensures it doesn't crash
+
         try:
             db1.insert("from_db1_again", sample_vectors["vec2"])
             db2.insert("from_db2", sample_vectors["vec3"])
         except Exception:
-            # Concurrent writes may fail - that's acceptable for now
             pass
-        
+
         db1.close()
         db2.close()
 
 
 class TestDirectoryHandling:
-    
     def test_nested_directory_creation(self, sample_vectors):
-        """Test database creation in nested directories"""
+        """Test database creation in nested directories."""
         nested_path = "test_nested/deep/very/deep/database.db"
-        
+
         try:
-            # Should create all parent directories
             db = VectorLiteDB(nested_path, dimension=3)
             db.insert("test", sample_vectors["vec1"])
             db.close()
-            
-            # Verify file exists
+
             assert os.path.exists(nested_path)
             assert os.path.isfile(nested_path)
-            
-            # Verify data persisted
+
             db2 = VectorLiteDB(nested_path)
             vector, _ = db2.get("test")
             assert vector == sample_vectors["vec1"]
             db2.close()
-            
         finally:
-            # Cleanup
-            if os.path.exists(nested_path):
-                os.remove(nested_path)
-                # Remove directories (from deepest to shallowest)
-                dirs_to_remove = ["test_nested/deep/very/deep", 
-                                "test_nested/deep/very", 
-                                "test_nested/deep", 
-                                "test_nested"]
-                for dir_path in dirs_to_remove:
-                    if os.path.exists(dir_path):
-                        os.rmdir(dir_path)
-    
+            for path in [nested_path, nested_path + ".wal", nested_path + ".tmp"]:
+                if os.path.exists(path):
+                    os.remove(path)
+
+            dirs_to_remove = [
+                "test_nested/deep/very/deep",
+                "test_nested/deep/very",
+                "test_nested/deep",
+                "test_nested",
+            ]
+            for dir_path in dirs_to_remove:
+                if os.path.exists(dir_path):
+                    os.rmdir(dir_path)
+
     def test_relative_vs_absolute_paths(self, sample_vectors):
-        """Test that relative and absolute paths work correctly"""
-        # Test relative path
+        """Test that relative and absolute paths work correctly."""
         rel_path = "relative_test.db"
-        
+
         try:
             db1 = VectorLiteDB(rel_path, dimension=3)
             db1.insert("test", sample_vectors["vec1"])
             db1.close()
-            
-            # Test absolute path to same file
+
             abs_path = os.path.abspath(rel_path)
             db2 = VectorLiteDB(abs_path)
             vector, _ = db2.get("test")
             assert vector == sample_vectors["vec1"]
             db2.close()
-            
         finally:
-            for path in [rel_path, os.path.abspath(rel_path)]:
+            for path in [
+                rel_path,
+                rel_path + ".wal",
+                rel_path + ".tmp",
+                os.path.abspath(rel_path),
+                os.path.abspath(rel_path) + ".wal",
+                os.path.abspath(rel_path) + ".tmp",
+            ]:
                 if os.path.exists(path):
                     os.remove(path)
 
 
 class TestBackupAndRestore:
-    
     def test_manual_file_copy_backup(self, temp_db_path, sample_vectors):
-        """Test that manually copying database file works as backup"""
-        # Create original database
+        """Test that manually copying database file works as backup."""
         db = VectorLiteDB(temp_db_path, dimension=3)
         for vec_id, vector in sample_vectors.items():
             db.insert(vec_id, vector, {"backup_test": True})
         db.close()
-        
-        # Create backup by copying file
+
         backup_path = temp_db_path + ".backup"
-        with open(temp_db_path, 'rb') as src, open(backup_path, 'wb') as dst:
+        with open(temp_db_path, "rb") as src, open(backup_path, "wb") as dst:
             dst.write(src.read())
-        
+
         try:
-            # Modify original
             db = VectorLiteDB(temp_db_path)
             db.delete("vec1")
             db.insert("new_vec", [9, 9, 9], {"modified": True})
             db.close()
-            
-            # Restore from backup
+
             os.remove(temp_db_path)
             os.rename(backup_path, temp_db_path)
-            
-            # Verify restoration
+
             db_restored = VectorLiteDB(temp_db_path)
-            assert len(db_restored) == len(sample_vectors)  # Original count
-            
-            # Original data should be there
+            assert len(db_restored) == len(sample_vectors)
+
             vector, metadata = db_restored.get("vec1")
             assert vector == sample_vectors["vec1"]
             assert metadata["backup_test"] is True
-            
-            # Modified data should not be there
+
             with pytest.raises(KeyError):
                 db_restored.get("new_vec")
-            
+
             db_restored.close()
-            
         finally:
-            # Cleanup
             if os.path.exists(backup_path):
                 os.remove(backup_path)
 
 
 class TestLargeDataPersistence:
-    
     def test_large_database_persistence(self, temp_db_path):
-        """Test persistence with large amounts of data"""
-        import numpy as np
-        
+        """Test persistence with large amounts of data."""
         db = VectorLiteDB(temp_db_path, dimension=128)
-        
-        # Insert 1000 vectors
-        np.random.seed(42)  # Reproducible
+
+        np.random.seed(42)
         vectors_to_insert = {}
-        
+
         for i in range(1000):
             vector = np.random.rand(128).tolist()
             vectors_to_insert[f"vec_{i:04d}"] = vector
             metadata = {"index": i, "batch": i // 100}
             db.insert(f"vec_{i:04d}", vector, metadata)
-        
+
         db.close()
-        
-        # Reopen and verify all data
+
         db2 = VectorLiteDB(temp_db_path)
         assert len(db2) == 1000
-        
-        # Spot check some vectors
+
         for i in [0, 100, 500, 999]:
             vec_id = f"vec_{i:04d}"
             vector, metadata = db2.get(vec_id)
             assert vector == vectors_to_insert[vec_id]
             assert metadata["index"] == i
-        
-        # Test search still works
+
         query = np.random.rand(128).tolist()
         results = db2.search(query, top_k=10)
         assert len(results) == 10
-        
+
         db2.close()


### PR DESCRIPTION
## Summary
- add a sidecar WAL (`.wal`) for `insert()` and `delete()` operations
- replay WAL records on startup before serving reads
- checkpoint back into the main `.db` file on `close()` and after an internal write threshold
- keep the public constructor and CRUD API unchanged

## Notes
This is an intentionally scoped v1 for issue #2.

Included here:
- append-only JSONL WAL records
- startup replay
- synchronous checkpointing on `close()`
- periodic checkpointing after a fixed internal write threshold
- README notes covering the persistence model

Not included here:
- background checkpoint threads
- user-configurable WAL settings
- broader concurrency changes

## Validation
- `python -m ruff check src\\vectorlitedb\\db.py tests\\conftest.py tests\\test_persistence.py`
- `python -m pytest tests -q -o addopts=''`

Closes #2